### PR TITLE
Remove dependency on tokbox

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,8 +52,6 @@ allprojects {
     maven {
       url 'https://s3.amazonaws.com/salesforcesos.com/android/maven/release'
     }
-    maven {
-      url 'http://tokbox.bintray.com/maven/'
-    }
+    mavenCentral()
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-salesforce-chat",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React native support for Salesforce live chat",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
     "chat"
   ],
   "peerDependencies": {
-    "react-native": "^0.41.2"
+    "react-native": "^0.65.1"
   },
   "author": "Andrew Bestbier <andrew.bestbier@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Building this lib often fails as the tokbox maven location seems unreliable. Trying with just `mavenCentral()`
```* What went wrong:
Execution failed for task ':react-native-salesforce-chat:mergeReleaseResources'.
> Could not resolve all files for configuration ':react-native-salesforce-chat:releaseRuntimeClasspath'.
   > Could not resolve com.facebook.react:react-native:+.
     Required by:
         project :react-native-salesforce-chat
      > Failed to list versions for com.facebook.react:react-native.
         > Unable to load Maven meta-data from https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml.
            > Could not get resource 'https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml'.
               > Could not GET 'https://salesforcesos.com/android/maven/release/com/facebook/react/react-native/maven-metadata.xml'.
                  > salesforcesos.com: nodename nor servname provided, or not known
      > Failed to list versions for com.facebook.react:react-native.
         > Unable to load Maven meta-data from http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml.
            > Could not get resource 'http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml'.
               > Could not GET 'http://tokbox.bintray.com/maven/com/facebook/react/react-native/maven-metadata.xml'. Received status code 502 from server: Bad Gateway
```